### PR TITLE
fix java call

### DIFF
--- a/forceatlas/layout.py
+++ b/forceatlas/layout.py
@@ -40,31 +40,31 @@ def fa2_layout(
     seed=None,
 ):
     """Position nodes using ForceAtlas2 force-directed algorithm.
-
+    
     Parameters
     ----------
     G : NetworkX graph or list of nodes
         A position will be assigned to every node in G.
-
-    pos : dict or None  optional (default=None)
+    
+    pos : dict or None, optional (default=None)
         Initial positions for nodes as a dictionary with node as keys
         and values as a coordinate list or tuple.  If None, then use
         random initial positions.
-
-    iterations : int  optional (default=50)
-        Maximum number of iterations taken
-
-    threshold : float or None  optional (default=None)
+    
+    iterations : int, optional (default=50)
+        Maximum number of iterations taken.
+    
+    threshold : float or None, optional (default=None)
         Threshold for relative error in node position changes.
         The iteration stops if the error is below this threshold.
         
     directed : bool (default=False)
         Whether input graph is directed.
-
+    
     dim : int (default: 2)
         Dimension of layout.
         
-    splits : int or None  optional (default=None)
+    splits : int or None, optional (default=None)
         Rounds of splits to use for Barnes-Hut tree building.
         Number of regions after splitting is 4^barnesHutSplits for 2D
         and 8^barnesHutSplits for 3D.
@@ -84,10 +84,10 @@ def fa2_layout(
         Lower gives less speed and more precision.
         
     lin_log_mode : bool (default=False)
-        Switch ForceAtlas' model from lin-lin to lin-log. 
+        Switch ForceAtlas' model from lin-lin to lin-log.
         Makes clusters more tight.
         
-    repulsion : float or None  optional (default: 1)
+    repulsion : float or None, optional (default: 1)
         How much repulsion you want. More makes a more sparse graph.
         None will default to 2.0 if nodes >= 100, otherwise 10.0.
         
@@ -95,32 +95,22 @@ def fa2_layout(
         Attracts nodes to the center.
         
     strong_gravity_mode : bool (default=False)
-        A stronger gravity law
+        A stronger gravity law.
         
     outbound_attraction_distribution : bool (default=False)
         Distributes attraction along outbound edges.
         Hubs attract less and thus are pushed to the borders.
         
-    n_jobs : int  optional (defaults to all cores)
+    n_jobs : int, optional (defaults to all cores)
         Number of threads to use for parallel computation.
-        If None, defaults to all cores as detected by
-        multiprocessing.cpu_count().
-
-    seed : int or None  optional (default=None)
+        
+    seed : int or None, optional (default=None)
         Seed for random number generation for initial node position.
-        If int, `seed` is the seed used by the random number generator,
-        if None, the random number generator is chosen randomly.
-
+    
     Returns
     -------
     pos : dict
-        A dictionary of positions keyed by node
-
-    Examples
-    --------
-    >>> import forceatlas as fa2
-    >>> G = nx.path_graph(4)
-    >>> pos = fa2.fa2_layout(G)
+        A dictionary of positions keyed by node.
     """
     try:
         if not isinstance(G, nx.Graph):
@@ -138,63 +128,49 @@ def fa2_layout(
         output_filename = temp_filename() + ".coords"
         
         command = [
-                "java",
-                "-Djava.awt.headless=true",
-                "-Xmx8g",
-                "-cp",
-                classpath,
-                "kco.forceatlas2.Main",
-                "--input",
-                temp_graph_filename,
-                "--output",
-                output_filename,
-                "--nthreads",
-                str(n_jobs),
-                "--barnesHutTheta",
-                str(theta),
-                "--barnesHutUpdateIter",
-                str(update_iter),
-                "--jitterTolerance",
-                str(jitter_tolerance),
-                "--gravity",
-                str(gravity),
+            "java",
+            "-Djava.awt.headless=true",
+            "-Xmx8g",
+            "-cp",
+            classpath,
+            "kco.forceatlas2.Main",
+            "--input", temp_graph_filename,
+            "--output", output_filename,
+            "--nthreads", str(n_jobs),
+            "--barnesHutTheta", str(theta),
+            "--barnesHutUpdateIter", str(update_iter),
+            "--jitterTolerance", str(jitter_tolerance),
+            "--gravity", str(gravity),
         ]
         
-        if dim == 2:
-            command.append("--2d")
-            
         if seed is not None:
             command.extend(["--seed", str(seed)])
-            
-        if splits is not None:
-            command.extend(["--barnesHutSplits", str(splits)])
-            
-        if update_center:
-            command.append("--updateCenter")
-            
-        if lin_log_mode:
-            command.append("--linLogMode")
-            
         if repulsion is not None:
             command.extend(["--scalingRatio", str(repulsion)])
-            
-        if strong_gravity_mode:
-            command.append("--strongGravityMode")
+        if splits is not None:
+            command.extend(["--barnesHutSplits", str(splits)])
         
-        if outbound_attraction_distribution:
-            command.append("--outboundAttractionDistribution")
-            
+        # Add boolean or key-value flags.
+        if dim == 2:
+            command.append("--2d")
+        # update_center, directed are defined as boolean flags in the Java code.
+        if update_center:
+            command.append("--updateCenter")
         if directed:
             command.append("--directed")
-            
+        
+        # For flags defined as key–value (they expect a value), we supply "true" or "false".
+        command.extend(["--linLogMode", "true" if lin_log_mode else "false"])
+        command.extend(["--strongGravityMode", "true" if strong_gravity_mode else "false"])
+        command.extend(["--outboundAttractionDistribution", "true" if outbound_attraction_distribution else "false"])
+        
+        # Add iteration stopping parameters.
         if threshold is None:
             command.extend(["--nsteps", str(iterations)])
         else:
             command.extend([
-                "--targetChangePerNode",
-                str(threshold),
-                "--targetSteps",
-                str(iterations),
+                "--targetChangePerNode", str(threshold),
+                "--targetSteps", str(iterations),
             ])
             
         if pos is not None:
@@ -206,7 +182,7 @@ def fa2_layout(
                     row["z"] = coords[2]
                 pos_list.append(row)
             pos_list = pd.DataFrame(pos_list)
-            pos_list.to_csv(temp_pos_filename, sep='\t')
+            pos_list.to_csv(temp_pos_filename, sep='\t', index=False)
             command.extend(["--coords", temp_pos_filename])
             
         subprocess.check_call(command)
@@ -231,7 +207,6 @@ def fa2_layout(
         for path in [temp_graph_filename, output_filename + ".txt", output_filename + ".distances.txt"]:
             if os.path.exists(path):
                 os.remove(path)
-                
         while True:
             try:
                 os.remove(temp_pos_filename)
@@ -240,4 +215,3 @@ def fa2_layout(
                 continue
             except:
                 break
-            


### PR DESCRIPTION
This pull request fixes an argument parsing issue in the Python wrapper for ForceAtlas2. Previously, boolean flags such as --linLogMode, --strongGravityMode, and --outboundAttractionDistribution were passed without an explicit value, causing the Java backend to misinterpret the following argument as their value.

Changes:

For flags defined as key–value in the Java code, the Python wrapper now always supplies an explicit "true" or "false" value.

Boolean flags that don't require a value (like --2d, --updateCenter, and --directed) remain unchanged.

Why:
This change prevents runtime errors like ArrayIndexOutOfBoundsException by ensuring the Java parser receives the correct argument format, improving compatibility and robustness.

Feel free to review and merge!